### PR TITLE
Convert None types to empty strings

### DIFF
--- a/metadata_plugin.py
+++ b/metadata_plugin.py
@@ -117,16 +117,16 @@ def convert_to_supported_type(ansible_value) -> typing.Dict:
         for i in ansible_value:
             new_list.append(convert_to_supported_type(i))
         return new_list
-    if type_of_val == dict:
+    elif type_of_val == dict:
         result = {}
         for k in ansible_value:
             result[convert_to_supported_type(k)] = convert_to_supported_type(
                 ansible_value[k]
             )
         return result
-    if type_of_val in (float, int, str, bool):
+    elif type_of_val in (float, int, str, bool):
         return ansible_value
-    if type_of_val == type(None):
+    elif type_of_val == type(None):
         return str("")
     elif type_of_val == AnsibleUnsafeText:
         return str(ansible_value)

--- a/metadata_plugin.py
+++ b/metadata_plugin.py
@@ -124,8 +124,10 @@ def convert_to_supported_type(ansible_value) -> typing.Dict:
                 ansible_value[k]
             )
         return result
-    if type_of_val in (float, int, str, bool, type(None)):
+    if type_of_val in (float, int, str, bool):
         return ansible_value
+    if type_of_val == type(None):
+        return str("")
     elif type_of_val == AnsibleUnsafeText:
         return str(ansible_value)
     else:

--- a/metadata_plugin.py
+++ b/metadata_plugin.py
@@ -126,7 +126,7 @@ def convert_to_supported_type(ansible_value) -> typing.Dict:
         return result
     elif type_of_val in (float, int, str, bool):
         return ansible_value
-    elif type_of_val == type(None):
+    elif isinstance(type_of_val, type(None)):
         return str("")
     elif type_of_val == AnsibleUnsafeText:
         return str(ansible_value)


### PR DESCRIPTION
## Changes introduced with this PR

As the `any` type support for the schema does not support `null` values, we'll convert any `None` type values to empty strings to ensure that that the `any` type will accept the value as input.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).