### PR TITLE
Standardize the data type for all items in a list

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+doctests = True
+exclude = .venv,.git,.tox,dist,doc,build,__pycache__
+max-line-length = 88

--- a/metadata_plugin.py
+++ b/metadata_plugin.py
@@ -116,7 +116,18 @@ def convert_to_supported_type(ansible_value) -> typing.Dict:
         new_list = []
         for i in ansible_value:
             new_list.append(convert_to_supported_type(i))
-        return new_list
+        # A list needs to be of a consistent type or it will
+        # not be indexible into a system like Elasticsearch
+        list_type = str()
+        for j in new_list:
+            if type(j) in (str, bool, type(None)):
+                list_type = str()
+                break
+            elif type(j) == float:
+                list_type = float()
+            elif type(j) == int and type(list_type) != float:
+                list_type = int()
+        return list(map(type(list_type), new_list))
     elif type_of_val == dict:
         result = {}
         for k in ansible_value:

--- a/metadata_plugin.py
+++ b/metadata_plugin.py
@@ -90,8 +90,7 @@ def collect_metadata(
         tasks=[],
     )
 
-    play = Play()\
-        .load(play_source, variable_manager=variable_manager, loader=loader)
+    play = Play().load(play_source, variable_manager=variable_manager, loader=loader)
 
     try:
         tqm.run(play)

--- a/metadata_plugin.py
+++ b/metadata_plugin.py
@@ -118,16 +118,7 @@ def convert_to_supported_type(ansible_value) -> typing.Dict:
             new_list.append(convert_to_supported_type(i))
         # A list needs to be of a consistent type or it will
         # not be indexible into a system like Elasticsearch
-        list_type = str()
-        for j in new_list:
-            if type(j) in (str, bool, type(None)):
-                list_type = str()
-                break
-            elif type(j) == float:
-                list_type = float()
-            elif type(j) == int and type(list_type) != float:
-                list_type = int()
-        return list(map(type(list_type), new_list))
+        return convert_to_homogenous_list(new_list)
     elif type_of_val == dict:
         result = {}
         for k in ansible_value:
@@ -144,6 +135,23 @@ def convert_to_supported_type(ansible_value) -> typing.Dict:
     else:
         print("Unknown type", type_of_val, "with val", str(ansible_value))
         return str(ansible_value)
+
+
+def convert_to_homogenous_list(input_list: list):
+    # To make all types in list homogeneous, we upconvert them
+    # to the least commom type.
+    # int -> float -> str
+    # bool + None -> str
+    list_type = str()
+    for j in input_list:
+        if type(j) in (str, bool, type(None)):
+            list_type = str()
+            break
+        elif type(j) == float:
+            list_type = float()
+        elif type(j) == int and type(list_type) != float:
+            list_type = int()
+    return list(map(type(list_type), input_list))
 
 
 if __name__ == "__main__":

--- a/test_metadata_plugin.py
+++ b/test_metadata_plugin.py
@@ -38,6 +38,34 @@ class HelloWorldTest(unittest.TestCase):
         self.assertTrue("env" in output_data.metadata)
         self.assertTrue("distribution" in output_data.metadata)
 
+    def test_convert_to_homogeneous_list(self):
+        test_cases = [
+            ["a", "b", "c"], # all str
+            ["a", "b", 1], # One final int to convert to str
+            [1.0, 1, "1"], # str at end, so upconvert all to str
+            ["1", 1, 1.0],
+            ["1", 1, 1],
+            [1, 1, "1"],
+            [1, 1, 1],
+            [1.0, 1, 1],
+            [1, 1, 1.0],
+        ]
+        # Ensure they're all homogeneous
+        for test_case in test_cases:
+            validate_list_items_homogeous_type(self,
+                metadata_plugin.convert_to_homogenous_list(test_case))
+        # Ensure the type matches
+        self.assertEqual(int, type(metadata_plugin.convert_to_homogenous_list([1, 1, 1])[0]))
+        self.assertEqual(float, type(metadata_plugin.convert_to_homogenous_list([1, 1, 1.0])[0]))
+        self.assertEqual(str, type(metadata_plugin.convert_to_homogenous_list([1, 1.0, "1.0"])[0]))
+
+
+def validate_list_items_homogeous_type(t, input_list):
+    if len(input_list) == 0:
+        return # no problem with an empty list
+    expected_type = type(input_list[0])
+    for item in input_list:
+        t.assertEqual(type(item), expected_type)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_metadata_plugin.py
+++ b/test_metadata_plugin.py
@@ -40,9 +40,9 @@ class HelloWorldTest(unittest.TestCase):
 
     def test_convert_to_homogeneous_list(self):
         test_cases = [
-            ["a", "b", "c"], # all str
-            ["a", "b", 1], # One final int to convert to str
-            [1.0, 1, "1"], # str at end, so upconvert all to str
+            ["a", "b", "c"],  # all str
+            ["a", "b", 1],  # One final int to convert to str
+            [1.0, 1, "1"],  # str at end, so upconvert all to str
             ["1", 1, 1.0],
             ["1", 1, 1],
             [1, 1, "1"],
@@ -52,20 +52,28 @@ class HelloWorldTest(unittest.TestCase):
         ]
         # Ensure they're all homogeneous
         for test_case in test_cases:
-            validate_list_items_homogeous_type(self,
-                metadata_plugin.convert_to_homogenous_list(test_case))
+            validate_list_items_homogeous_type(
+                self, metadata_plugin.convert_to_homogenous_list(test_case)
+            )
         # Ensure the type matches
-        self.assertEqual(int, type(metadata_plugin.convert_to_homogenous_list([1, 1, 1])[0]))
-        self.assertEqual(float, type(metadata_plugin.convert_to_homogenous_list([1, 1, 1.0])[0]))
-        self.assertEqual(str, type(metadata_plugin.convert_to_homogenous_list([1, 1.0, "1.0"])[0]))
+        self.assertEqual(
+            int, type(metadata_plugin.convert_to_homogenous_list([1, 1, 1])[0])
+        )
+        self.assertEqual(
+            float, type(metadata_plugin.convert_to_homogenous_list([1, 1, 1.0])[0])
+        )
+        self.assertEqual(
+            str, type(metadata_plugin.convert_to_homogenous_list([1, 1.0, "1.0"])[0])
+        )
 
 
 def validate_list_items_homogeous_type(t, input_list):
     if len(input_list) == 0:
-        return # no problem with an empty list
+        return  # no problem with an empty list
     expected_type = type(input_list[0])
     for item in input_list:
         t.assertEqual(type(item), expected_type)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Changes introduced with this PR

The ansible_facts output can return lists that have items with various data types. This will break indexing with Elasticsearch since it expects a single data type for all items in a list. This change iterates through the list items to set a single standard data type based on the existing values and types in the list.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).