### PR TITLE
Use `ansible-core`, update `requirements.txt`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1,21 +1,10 @@
 [[package]]
-name = "ansible"
-version = "6.6.0"
-description = "Radically simple IT automation"
-category = "main"
-optional = false
-python-versions = ">=3.8"
-
-[package.dependencies]
-ansible-core = ">=2.13.6,<2.14.0"
-
-[[package]]
 name = "ansible-core"
-version = "2.13.6"
+version = "2.14.0"
 description = "Radically simple IT automation"
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 
 [package.dependencies]
 cryptography = "*"
@@ -499,16 +488,12 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "3b18f746b7c0a0202b498d8116a2945ac45e8dfcdd63263bdf8dc1a4e9b5ff14"
+content-hash = "239754e6c792cc8d44e661fdeedae02f6181c3c96ccc2b6e7e37fa83fc419e73"
 
 [metadata.files]
-ansible = [
-    {file = "ansible-6.6.0-py3-none-any.whl", hash = "sha256:3c6812e9af1c243b8a9e5fc6cba618449813765e609caae39a757452e2818dee"},
-    {file = "ansible-6.6.0.tar.gz", hash = "sha256:e1b940a8d4f412123ede3c14b25cb99c3c8a4d535fd040aabf8e4fb7b0e4f092"},
-]
 ansible-core = [
-    {file = "ansible-core-2.13.6.tar.gz", hash = "sha256:31fe322b63290674a8f7386110df501f0044aa44890be3ab313a6e225b9a29cf"},
-    {file = "ansible_core-2.13.6-py3-none-any.whl", hash = "sha256:e31fd550a5ea9423f1fc1391de6b41bb0d264a83bbfc9c7edfef0f78b7624fd3"},
+    {file = "ansible-core-2.14.0.tar.gz", hash = "sha256:fa48b481cb623bf79bb903f223097681a0c13e1b4ec7e78e7dd7d858d36a34b2"},
+    {file = "ansible_core-2.14.0-py3-none-any.whl", hash = "sha256:b191d397c81514bd1922e00e16f0b8ec52e0bcb19b61cc4500085f5f92470cf2"},
 ]
 ansible-runner = [
     {file = "ansible-runner-2.3.1.tar.gz", hash = "sha256:1d2f02d3a62573f38e68a23790118b7981791c2bed2b5f22f7a36a221c288756"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0+GPL-2.0-only"
 [tool.poetry.dependencies]
 python = "^3.9"
 arcaflow-plugin-sdk = "0.9.0"
-ansible = "^6.5.0"
+ansible-core = "^2.14.0"
 ansible-runner = "2.3.1"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,9 @@
-ansible-core==2.13.6 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:31fe322b63290674a8f7386110df501f0044aa44890be3ab313a6e225b9a29cf \
-    --hash=sha256:e31fd550a5ea9423f1fc1391de6b41bb0d264a83bbfc9c7edfef0f78b7624fd3
+ansible-core==2.14.0 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:b191d397c81514bd1922e00e16f0b8ec52e0bcb19b61cc4500085f5f92470cf2 \
+    --hash=sha256:fa48b481cb623bf79bb903f223097681a0c13e1b4ec7e78e7dd7d858d36a34b2
 ansible-runner==2.3.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:1d2f02d3a62573f38e68a23790118b7981791c2bed2b5f22f7a36a221c288756 \
     --hash=sha256:f26d409293964d3a90c1af1acfd32d461f314f4405b72308d62f65d8ac4c0621
-ansible==6.6.0 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:3c6812e9af1c243b8a9e5fc6cba618449813765e609caae39a757452e2818dee \
-    --hash=sha256:e1b940a8d4f412123ede3c14b25cb99c3c8a4d535fd040aabf8e4fb7b0e4f092
 arcaflow-plugin-sdk==0.9.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:1254df74d59a7d54f7d046a35b6173db56096299dc0acfc9a1432da75ce1da83 \
     --hash=sha256:21b22b634148e07fcd636a7263b2dc50a92dcbd2cbad7b72b799345b851b9d5c


### PR DESCRIPTION
## Changes introduced with this PR

Use `ansible-core`, update `requirements.txt`; we don't need to use the very large `ansible` module just to get the `AnsibleUnsafeText` class when it is provided via `ansible-core`.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).