### PR TITLE
Fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ COPY tests /app/tests
 
 RUN mkdir /htmlcov
 RUN pip3 install coverage
-RUN ansible -m gather_facts localhost |grep machine
 RUN python3 -m coverage run tests/test_metadata_plugin.py
 RUN python3 -m coverage html -d /htmlcov --omit=/usr/local/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 
 COPY poetry.lock /app/
 COPY pyproject.toml /app/
+COPY ${package}/ /app/${package}
 
 RUN python3.9 -m pip install poetry \
  && python3.9 -m poetry config virtualenvs.create false \
@@ -16,13 +17,11 @@ RUN python3.9 -m pip install poetry \
  && python3.9 -m poetry export -f requirements.txt --output requirements.txt --without-hashes
 
 # run tests
-COPY ${package}/ /app/${package}
 COPY tests /app/tests
-
-ENV PYTHONPATH /app/${package}
 
 RUN mkdir /htmlcov
 RUN pip3 install coverage
+RUN ansible -m gather_facts localhost |grep machine
 RUN python3 -m coverage run tests/test_metadata_plugin.py
 RUN python3 -m coverage html -d /htmlcov --omit=/usr/local/*
 
@@ -42,12 +41,14 @@ COPY ${package}/ /app/${package}
 
 RUN python3.9 -m pip install -r requirements.txt
 
-ENTRYPOINT ["python3", "-m", "arcaflow_plugin_metadata.metadata_plugin"]
+WORKDIR /app/${package}
+
+ENTRYPOINT ["python3", "metadata_plugin.py"]
 CMD []
 
 LABEL org.opencontainers.image.source="https://github.com/arcalot/arcaflow-plugin-metadata"
 LABEL org.opencontainers.image.licenses="Apache-2.0+GPL-2.0-only"
 LABEL org.opencontainers.image.vendor="Arcalot project"
 LABEL org.opencontainers.image.authors="Arcalot contributors"
-LABEL org.opencontainers.image.title="Python Plugin Template"
+LABEL org.opencontainers.image.title="Arcaflow metadata plugin"
 LABEL io.github.arcalot.arcaflow.plugin.version="1"

--- a/arcaflow_plugin_metadata/metadata_schema.py
+++ b/arcaflow_plugin_metadata/metadata_schema.py
@@ -70,12 +70,12 @@ class SelectedFacts:
         }
     )
 
-    machine_id: str = field(
-        metadata={
-            "name": "ansible machine ID",
-            "description": "The system machine ID",
-        }
-    )
+    # machine_id: str = field(
+    #     metadata={
+    #         "name": "ansible machine ID",
+    #         "description": "The system machine ID",
+    #     }
+    # )
 
     memtotal_mb: int = field(
         metadata={

--- a/tests/test_metadata_plugin.py
+++ b/tests/test_metadata_plugin.py
@@ -15,7 +15,7 @@ class MetadataTest(unittest.TestCase):
                 fqdn="foo.bar",
                 architecture="x86_64",
                 kernel="1.2.3.test4",
-                machine_id="abc123",
+                # machine_id="abc123",
                 memtotal_mb=10,
                 swaptotal_mb=5,
                 processor_cores=8,


### PR DESCRIPTION
## Changes introduced with this PR

It appears perhaps that some drift in the ansible gather facts output has led to the removal of `machine_id` from the results, causing the tests to fail at build time. I so far have not found a reference to this change with ansible, so I've just commented out the affected part of the schema for now.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).