### PR TITLE
explicitly set locale

### DIFF
--- a/arcaflow_plugin_metadata/metadata_plugin.py
+++ b/arcaflow_plugin_metadata/metadata_plugin.py
@@ -2,6 +2,7 @@
 
 import sys
 import typing
+import locale
 from arcaflow_plugin_sdk import plugin
 from ansible.utils.unsafe_proxy import AnsibleUnsafeText
 import ansible_runner
@@ -25,6 +26,8 @@ def collect_metadata(
 ) -> typing.Tuple[str, typing.Union[SelectedFacts, ErrorOutput]]:
     ansible_host = "localhost"
     selected_facts = {}
+
+    locale.setlocale(locale.LC_ALL, "C.UTF-8")
 
     try:
         r = ansible_runner.run(


### PR DESCRIPTION
## Changes introduced with this PR

The plugin is failing in some aarch64 test environments due to a default locale setting that is unsupported by ansible. This explicitly sets the locale for the script and corrects the problem.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).