### PR TITLE
capture subprocess failures from ansible_runner

### DIFF
--- a/arcaflow_plugin_metadata/metadata_plugin.py
+++ b/arcaflow_plugin_metadata/metadata_plugin.py
@@ -38,7 +38,6 @@ def collect_metadata(
         )
 
         if r.rc != 0:
-            # print(r.stderr.read())
             return "error", ErrorOutput(
                 f"Unable to gather facts: ({r.rc}) {r.stdout.read()}"
             )
@@ -55,8 +54,8 @@ def collect_metadata(
 
         return "success", selected_facts_schema.unserialize(output)
 
-    except KeyError:
-        return "error", ErrorOutput("Missing a key in ansible facts")
+    except KeyError as exc:
+        return "error", ErrorOutput(f"Missing a key in ansible facts: {exc}")
 
 
 def convert_to_supported_type(ansible_value) -> typing.Dict:

--- a/arcaflow_plugin_metadata/metadata_plugin.py
+++ b/arcaflow_plugin_metadata/metadata_plugin.py
@@ -36,6 +36,13 @@ def collect_metadata(
             module="gather_facts",
             quiet=True,
         )
+
+        if r.rc != 0:
+            # print(r.stderr.read())
+            return "error", ErrorOutput(
+                f"Unable to gather facts: ({r.rc}) {r.stdout.read()}"
+            )
+
         host_ansible_facts = r.get_fact_cache(ansible_host)
 
         for fact, value in host_ansible_facts.items():
@@ -49,7 +56,7 @@ def collect_metadata(
         return "success", selected_facts_schema.unserialize(output)
 
     except KeyError:
-        return "error", ErrorOutput("missing a key in ansible facts")
+        return "error", ErrorOutput("Missing a key in ansible facts")
 
 
 def convert_to_supported_type(ansible_value) -> typing.Dict:


### PR DESCRIPTION
## Changes introduced with this PR

The `ansible_runner` function can have an error condition that does not create an exception. This change adds a check for the return code of the subprocess and returns a plugin error if this is not 0.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).