### PR TITLE
Add ansible_local support for custom local facts

### DIFF
--- a/arcaflow_plugin_metadata/metadata_schema.py
+++ b/arcaflow_plugin_metadata/metadata_schema.py
@@ -133,13 +133,6 @@ class SelectedFacts:
         }
     )
 
-    product_name: str = field(
-        metadata={
-            "name": "ansible product name",
-            "description": "The system product name",
-        }
-    )
-
     processor: typing.List[str] = field(
         metadata={
             "name": "ansible processor",
@@ -159,6 +152,14 @@ class SelectedFacts:
             "name": "ansible uptime seconds",
             "description": "The system uptime in seconds",
         }
+    )
+
+    local: typing.Optional[typing.Dict[str, typing.Any]] = field(
+        default=None,
+        metadata={
+            "name": "ansible local",
+            "description": "Custom local facts from /etc/ansible/facts.d/",
+        },
     )
 
 

--- a/tests/test_arcaflow_plugin_metadata.py
+++ b/tests/test_arcaflow_plugin_metadata.py
@@ -15,7 +15,36 @@ class MetadataTest(unittest.TestCase):
                 fqdn="foo.bar",
                 architecture="x86_64",
                 kernel="1.2.3.test4",
-                # machine_id="abc123",
+                memtotal_mb=10,
+                swaptotal_mb=5,
+                processor_cores=8,
+                processor_count=4,
+                processor_threads_per_core=2,
+                product_name="narf",
+                product_version="a.b.c.1",
+                system_vendor="LENOVO",
+                processor=["0", "Intel", "Xeon", "1", "Intel", "Xeon"],
+                env={"FOO": "BAR", "NARF": "BLARG"},
+                uptime_seconds=9999,
+                local={
+                    "hardware": {
+                        "model": "Test System Model",
+                        "vendor": "Test Vendor",
+                        "features": ["feature_a", "feature_b"],
+                    },
+                    "site": {
+                        "location": "lab-1",
+                        "rack": "R01",
+                    },
+                },
+            )
+        )
+
+        plugin.test_object_serialization(
+            metadata_schema.SelectedFacts(
+                fqdn="foo.bar",
+                architecture="x86_64",
+                kernel="1.2.3.test4",
                 memtotal_mb=10,
                 swaptotal_mb=5,
                 processor_cores=8,
@@ -49,6 +78,25 @@ class MetadataTest(unittest.TestCase):
         self.assertIsInstance(output_data.kernel, str)
         self.assertIsInstance(output_data.processor, list)
         self.assertIsInstance(output_data.swaptotal_mb, int)
+
+    def test_convert_nested_dict(self):
+        nested = {
+            "hardware": {
+                "model": "Test System Model",
+                "features": ["feature_a", "feature_b"],
+            },
+            "site": {
+                "location": "lab-1",
+                "rack": "R01",
+            },
+        }
+        result = metadata_plugin.convert_to_supported_type(nested)
+        self.assertEqual(result["hardware"]["model"], "Test System Model")
+        self.assertEqual(
+            result["hardware"]["features"],
+            ["feature_a", "feature_b"],
+        )
+        self.assertEqual(result["site"]["location"], "lab-1")
 
     def test_convert_to_homogeneous_list(self):
         test_cases = [


### PR DESCRIPTION
## Summary
- Add an optional `local` field (`Dict[str, Any]`) to the `SelectedFacts` schema so that custom facts from `/etc/ansible/facts.d/` are captured when present
- No changes needed in `metadata_plugin.py` — the existing filtering loop automatically picks up `ansible_local` → `local` once the schema property exists
- Remove a duplicate `product_name` field definition in the schema
- Add tests for serialization with and without local facts, and for nested dict type conversion

## Test plan
- [x] `test_serialization` passes with `local` data (nested dicts + lists)
- [x] `test_serialization` passes without `local` (defaults to `None`, field absent)
- [x] `test_convert_nested_dict` verifies nested structures survive `convert_to_supported_type()`
- [x] `test_convert_to_homogeneous_list` unchanged, still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)